### PR TITLE
Virtualbox Version Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Installer for the Markup Laptops (mostly aimed at running VMs)
 - Ruby >= 2.4
 - PHP 7.1
 - Bundler (To install gems)
-- Virtualbox (to run virtual machines)
 - Vagrant (to aid running virtual machines
+
+Will check and instruct you on what to do to get VirtualBox installed but will not actually do it due to some restrictions in what Brew can do.
 
 ### How to use
 

--- a/init.sh
+++ b/init.sh
@@ -274,7 +274,7 @@ then
         if [ $? -ne 1 ]
         then
             clr_cyan "Set up environment variables for ZSH"
-            echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ./zshrc
+            echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ~/.zshrc
         fi
     elif [ $SHELL = "/bin/bash" ] 
     then
@@ -282,7 +282,7 @@ then
         if [ $? -ne 1 ]
         then
             clr_cyan "Set up environment variables for Bash"
-            echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ./bashrc
+            echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ~/.bashrc
         fi
     else
         echo "Your shell is not supported! In order to successfully use PHP7.1 you will need to set your path variable to export the new location for PHP7.1 as below:"

--- a/init.sh
+++ b/init.sh
@@ -205,9 +205,13 @@ cat >> /tmp/brewfile <<EOL
 # Taps
 tap "homebrew/core"
 tap "homebrew/bundle"
-tap "caskroom/cask"
+tap "homebrew/cask"
 tap "homebrew/cask-drivers"
 tap "homebrew/cask-versions"
+tap "exolnet/homebrew-deprecated"
+
+#Environment setup
+cask_args appdir: "/Applications"
 
 brew "openssl"
 brew "ruby"
@@ -225,10 +229,11 @@ cask "virtualbox"
 EOL
 
 cd /tmp/
-brew bundle
+brew bundle -v
 
 clr_magenta "> Checking for git (from Brew)."
 
+# Git
 which git | grep "/usr/local/bin" > /dev/null
 
 while [ $? -eq 1 ]
@@ -253,9 +258,38 @@ done
 
 clr_green "iTerm2 Installed"
 
+### PHP
+
 clr_magenta "> Checking for PHP 7.1"
 
 php -v | grep "7\.1\." > /dev/null
+if [ $? -ne 1 ]
+then
+    export PATH="/usr/local/opt/php@7.1/bin:$PATH"
+
+    #Check if the PATH contains the new PHP section already. If not, remove it
+    if [ $SHELL = "/bin/zsh" ] 
+    then
+        grep "php@7.1" ./zshrc
+        if [ $? -ne 1 ]
+        then
+            clr_cyan "Set up environment variables for ZSH"
+            echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ./zshrc
+        fi
+    elif [ $SHELL = "/bin/bash" ] 
+    then
+        grep "php@7.1" ./zshrc
+        if [ $? -ne 1 ]
+        then
+            clr_cyan "Set up environment variables for Bash"
+            echo 'export PATH="/usr/local/opt/php@7.1/bin:$PATH"' >> ./bashrc
+        fi
+    else
+        echo "Your shell is not supported! In order to successfully use PHP7.1 you will need to set your path variable to export the new location for PHP7.1 as below:"
+        echo "/usr/local/opt/php@7.1/bin"
+    fi
+fi
+
 
 while [ $? -eq 1 ]
 do

--- a/init.sh
+++ b/init.sh
@@ -225,7 +225,6 @@ cask "sequel-pro-nightly"
 cask "vagrant"
 cask "the-unarchiver"
 cask "iterm2"
-cask "virtualbox"
 EOL
 
 cd /tmp/
@@ -350,14 +349,23 @@ clr_green "Bundler Installed"
 #### Virtualbox
 clr_magenta "> Checking for Virtualbox."
 
-which VBoxManage > /dev/null
-
-while [ $? -eq 1 ]
-do
-    clr_bold clr_red "Virtualbox is not installed!!"
-
+which vboxmanage > /dev/null
+if [ $? -eq 1 ] 
+then
+    #Virtualbox 6.1 is not supported by Vagrant at this time and 6.0 is not available on brew at this time, hence it must be installed manually
+    clr_bold clr_green "Virtualbox is not installed!!"
+    clr_bold clr_green "Please install virtualbox 6.0 using the following URL"
+    clr_bold clr_green "https://www.virtualbox.org/wiki/Download_Old_Builds_6_0"
     exit 1
-done
+else
+    VBoxManage --version | grep "^6.0." > /dev/null
+    if [ $? -eq 1 ] 
+    then
+        clr_bold clr_green "Virtualbox is installed but is not at version 6.0. Please uninstall it and replace it with 6.0 from the Virtualbox site"    
+        clr_bold clr_green "https://www.virtualbox.org/wiki/Download_Old_Builds_6_0"
+        exit 1
+    fi
+fi
 
-clr_green "Virtualbox Installed"
+clr_green "Virtualbox is installed and is the correct version"
 


### PR DESCRIPTION
Vagrant currently does not support VirtualBox version 6.1 which is currently the version installed as part of the VirtualBox cask. This fix removes the VirtualBox cask and instead checks:

1. If VirtualBox is installed *at all*
2. If *correct version* of VirtualBox is installed

The script instructs the user to either remove and install the correct version or just install the correct version dependant on the situation. In both cases, the script will direct the user to the correct (at time of writing) URL in order to install 6.0. As you might expect, if the version of VirtualBox is 6.0, the user will be shown a message to that effect.